### PR TITLE
fix: Torna o carregamento de chaves de API mais robusto

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -35,7 +35,7 @@ API_KEYS_FILE = "api_keys.json"
 
 # --- Funções Auxiliares para Chaves de API ---
 def load_api_keys() -> Dict[str, str]:
-    if not os.path.exists(API_KEYS_FILE):
+    if not os.path.exists(API_KEYS_FILE) or os.path.getsize(API_KEYS_FILE) == 0:
         return {}
     try:
         with open(API_KEYS_FILE, "r") as f:


### PR DESCRIPTION
Melhora a função `load_api_keys` no backend para lidar corretamente com o arquivo `api_keys.json` quando ele está vazio.

Anteriormente, um arquivo vazio causava um `JSONDecodeError`, poluindo os logs e mascarando a causa raiz do problema (nenhuma chave configurada).

Esta correção adiciona uma verificação do tamanho do arquivo antes de tentar o parsing. Se o arquivo estiver vazio, a função agora retorna um dicionário vazio, o que evita o erro e leva a uma mensagem de log mais clara de "chave não configurada".