### PR TITLE
fix: Aumenta a robustez do backend com correções de bugs

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,7 @@ import logging
 import json
 import backoff
 from fastapi import FastAPI, HTTPException, Request, status, UploadFile, File, Form
-from fastapi.responses import StreamingResponse, JSONResponse
+from fastapi.responses import StreamingResponse, JSONResponse, Response
 from pydantic import BaseModel
 from typing import List, Dict, Any, Annotated
 import io
@@ -164,7 +164,7 @@ def delete_key(provider: str):
 
     save_api_keys(keys)
     log.info("api_key_deleted", provider=provider)
-    return JSONResponse(status_code=status.HTTP_204_NO_CONTENT)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 # --- Funções de Lógica de Negócios ---
@@ -363,7 +363,7 @@ async def chat_proxy(request: ChatRequest):
                     async for chunk in response.aiter_bytes():
                         yield chunk
             except httpx.HTTPStatusError as e:
-                body = e.response.content
+                body = await e.response.aread()
                 error_detail = body.decode()
                 logger.error("provider_api_error", status_code=e.response.status_code, response_body=error_detail)
                 yield f'{{"error": "PROVIDER_ERROR", "status_code": {e.response.status_code}, "detail": {json.dumps(error_detail)}}}'


### PR DESCRIPTION
Esta alteração corrige dois bugs menores, mas importantes, no backend, que foram identificados durante os testes da funcionalidade de upload:

1.  **Corrige Endpoint de Exclusão de Chaves**: O endpoint `DELETE /api/v1/keys/{provider}` estava usando `JSONResponse` para um status 204, o que causava um `TypeError`. A chamada foi corrigida para usar `Response(status_code=204)`, que é a forma correta de retornar uma resposta sem conteúdo.

2.  **Corrige Tratamento de Erro em Streaming**: A lógica de tratamento de erro no `chat_proxy` foi aprimorada para usar `await e.response.aread()` ao ler o corpo de uma resposta de erro em um fluxo assíncrono. Isso resolve um erro `httpx.ResponseNotRead` e garante que as falhas da API externa sejam sempre tratadas de forma robusta.