### PR TITLE
feat: Implementar extração de conteúdo focada por cargo

### DIFF
--- a/ANALISE_APP.md
+++ b/ANALISE_APP.md
@@ -45,6 +45,10 @@ As seguintes funcionalidades, anteriormente listadas como pontos de melhoria, fo
 - **Implementação:** Os prompts usados para gerar tópicos, subtópicos e aulas foram completamente reescritos com base em uma análise detalhada (`ANALISE_PROMPTS.md`). Os novos prompts seguem princípios de design instrucional mais rigorosos.
 - **Benefício:** A qualidade do conteúdo gerado foi significativamente melhorada. As aulas agora são mais densas em informação, melhor estruturadas, e menos repetitivas. A progressão do aprendizado se tornou mais lógica e coesa, resultando em guias de estudo mais eficazes.
 
+### 2.8. Extração de Conteúdo Focada por Cargo
+- **Implementação:** Ao criar um guia a partir de um arquivo (edital), o usuário agora pode especificar um "Cargo". Essa informação é usada para instruir a IA a focar sua análise e extração de conteúdo exclusivamente no que é relevante para aquele cargo específico, ignorando outras seções do documento.
+- **Benefício:** Resolve o problema de "Oceano de Texto" em documentos grandes com múltiplos cargos, garantindo que os guias de estudo gerados sejam altamente relevantes e precisos para o objetivo do usuário.
+
 ---
 
 ## 3. Próximos Passos e Melhorias Futuras

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ After the script finishes, the terminal will show a message indicating the addre
     -   Save the settings.
 3.  **Create Your Guide**:
     -   Navigate back to "My Guides" and click "Create New Guide."
+    -   Fill in the title and other details.
+    -   **To create from a syllabus:** attach a PDF or DOCX file.
+    -   **IMPORTANT:** If the syllabus contains multiple job roles, fill in the **"Specific Job Role"** field so the AI can focus its analysis on the correct content.
     -   The application will use the configured provider and model to generate the content.
 
 The rest of the features, such as lesson generation, Q&A, exporting, and audio downloads, work the same as in the previous version.

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -127,6 +127,9 @@ Após a execução do script, o terminal mostrará uma mensagem indicando o ende
     -   Salve as configurações.
 3.  **Crie seu Guia**:
     -   Volte para "Meus Guias" e clique em "Criar Novo Guia".
+    -   Preencha o título e outros detalhes.
+    -   **Para criar a partir de um edital:** anexe um arquivo PDF ou DOCX.
+    -   **IMPORTANTE:** Se o edital contiver múltiplos cargos, preencha o campo **"Cargo Específico"** para que a IA foque a análise no conteúdo correto.
     -   A aplicação usará o provedor e modelo configurados para gerar o conteúdo.
 
 O restante dos recursos, como a geração de aulas, perguntas, exportação e download de áudio, funciona da mesma forma que na versão anterior.

--- a/backend/main.py
+++ b/backend/main.py
@@ -214,6 +214,7 @@ async def call_llm_api(provider: str, model: str, messages: List[Dict[str, str]]
 async def create_guide_from_upload(
     file: Annotated[UploadFile, File()],
     title: Annotated[str, Form()],
+    job_role: Annotated[str, Form()],
     persona: Annotated[str, Form()],
     level: Annotated[str, Form()],
     context: Annotated[str, Form()],
@@ -223,7 +224,7 @@ async def create_guide_from_upload(
     """
     Recebe um arquivo (edital) e metadados para criar um novo guia de estudos.
     """
-    logger = log.bind(filename=file.filename, title=title)
+    logger = log.bind(filename=file.filename, title=title, job_role=job_role)
     logger.info("guide_upload_received")
 
     content = await file.read()
@@ -255,6 +256,15 @@ async def create_guide_from_upload(
 
     if len(text) > CONTEXT_MAX_LENGTH:
         logger.info("document_too_long_for_context", text_length=len(text))
+
+        job_role_instruction = ""
+        if job_role and job_role.strip():
+            job_role_instruction = (
+                "\n**IMPORTANTE:** O documento pode conter informações para vários cargos. "
+                f'Você DEVE focar sua análise e extração de conteúdo EXCLUSIVAMENTE no que for relevante para o cargo de: **"{job_role}"**. '
+                "Ignore seções sobre outros cargos.\n"
+            )
+
         summarization_prompt = f"""
 O seguinte texto foi extraído de um documento (edital de concurso). O texto é muito longo para ser usado diretamente.
 Sua tarefa é ler o texto e criar um resumo executivo focado EXCLUSIVAMENTE nos seguintes pontos:
@@ -262,13 +272,13 @@ Sua tarefa é ler o texto e criar um resumo executivo focado EXCLUSIVAMENTE nos 
 2.  Pesos ou importância de cada matéria ou tópico.
 3.  Critérios de avaliação ou formato das provas.
 4.  Conhecimentos específicos exigidos.
-
+{job_role_instruction}
 Seja conciso e direto. O objetivo é criar um "mapa de estudos" a partir do documento.
 
 Texto original:
 ---
 {text[:CONTEXT_MAX_LENGTH]}
-""" # Usa apenas uma parte para o resumo, para garantir que a requisição em si não falhe
+"""
 
         document_context = await call_llm_api(
             provider="openai",  # Usar um provedor padrão para tarefas internas
@@ -278,12 +288,16 @@ Texto original:
         logger.info("document_summarized", original_length=len(text), summary_length=len(document_context))
 
     # --- Geração dos Tópicos do Guia ---
-    # Usar um prompt semelhante ao do frontend, mas adaptado para o contexto do documento
+    job_role_context = ""
+    if job_role and job_role.strip():
+        job_role_context = f'- Cargo Alvo: "{job_role}"'
+
     generation_prompt = f"""
 Você é um especialista em design instrucional. Sua tarefa é criar uma jornada de aprendizado coesa e progressiva a partir do documento fornecido.
 
 **Contexto do Guia:**
 - Título: "{title}"
+{job_role_context}
 - Perfil do Aluno: "{persona}"
 - Nível: "{level}"
 - Objetivo Principal: "{objective}"
@@ -294,7 +308,7 @@ Você é um especialista em design instrucional. Sua tarefa é criar uma jornada
 {document_context}
 ---
 
-Com base em TODO o contexto fornecido (especialmente o Documento de Referência), gere de 7 a 9 tópicos principais para o guia de estudos.
+Com base em TODO o contexto fornecido (especialmente o Documento de Referência e o Cargo Alvo, se especificado), gere de 7 a 9 tópicos principais para o guia de estudos.
 
 REGRAS DE SAÍDA:
 - Liste de 7 a 9 tópicos, um por linha.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,6 +113,10 @@
           <input type="file" id="guide-file-input" accept=".pdf,.docx">
         </div>
         <div class="form-group">
+          <label for="guide-job-role-input">Cargo Específico (se houver edital)</label>
+          <input type="text" id="guide-job-role-input" placeholder="Ex: Analista de TI, Enfermeiro, Técnico Judiciário">
+        </div>
+        <div class="form-group">
           <label for="guide-persona-input">Perfil do aluno (opcional)</label>
           <input type="text" id="guide-persona-input" placeholder="Ex: 'Estudante de nível médio para concurso de escriturário. Foco em teoria e atendimento.' ou 'Programador júnior aprendendo Python para finanças.'">
         </div>
@@ -977,6 +981,7 @@ Por favor, atue como um tutor. NÃO me dê a resposta pronta. Em vez disso, rees
         const formData = new FormData();
         formData.append('file', file);
         formData.append('title', title);
+        formData.append('job_role', document.getElementById('guide-job-role-input').value.trim());
         formData.append('persona', document.getElementById('guide-persona-input').value.trim());
         formData.append('level', document.getElementById('guide-level-input').value.trim());
         formData.append('context', document.getElementById('guide-context-input').value.trim());


### PR DESCRIPTION
Esta alteração introduz a capacidade de especificar um "Cargo" ao criar um guia de estudos a partir de um documento (edital). Isso resolve o problema de "Oceano de Texto", onde a IA se perdia em documentos grandes com múltiplos cargos.

Principais mudanças:
- Adicionado um campo "Cargo Específico" na UI do modal de criação.
- Frontend atualizado para enviar o `job_role` ao backend.
- Endpoint do backend (`/api/v1/guides/upload`) modificado para aceitar e processar o `job_role`.
- Prompts de IA para sumarização e geração de tópicos foram aprimorados para usar o `job_role` como um filtro de contexto, garantindo que o conteúdo extraído seja relevante.
- Documentação (READMEs e ANALISE_APP.md) atualizada para refletir a nova funcionalidade.